### PR TITLE
create_route fails with Unknown error

### DIFF
--- a/nova/api/ec2/vpc.py
+++ b/nova/api/ec2/vpc.py
@@ -980,7 +980,7 @@ class VpcController(object):
 
         # find the route
         foundRoute = False
-        for route in route_table['routes']:
+        for route in route_table['routes']['route']:
             if route['prefix'] == cidr:
                 route['next_hop'] = next_hop
                 route['next_hop_type'] = next_hop_type
@@ -991,10 +991,10 @@ class VpcController(object):
             route = {'prefix': cidr,
                      'next_hop': next_hop,
                      'next_hop_type': next_hop_type}
-            route_table['routes'].append(route)
+            route_table['routes']['route'].append(route)
 
         # add route to the route table
-        route_dict = {'route': route_table['routes']}
+        route_dict = {'route': route_table['routes']['route']}
         req = {'routes': route_dict}
         try:
             route_rsp = neutron.update_route_table(route_table['id'],


### PR DESCRIPTION
Fix:
Corrected python dictionary lookup to get list of routes

I were getting following errors:
conn.create_route(rtable.id, '10.0.0.0/28', gateway_id='igw-default')

boto.exception.BotoServerError: BotoServerError: 500 Internal Server Error

<Response><Errors><Error><Code>TypeError</Code><Message>Unknown error occurred.
</Message></Error></Errors><RequestID>req-8d96ab7f-e72c-40a6-a4af-7137588ead1c
</RequestID></Response>