### PR TITLE
libvirt, vhostuser: Add support for OpenContrail vRouter

### DIFF
--- a/nova/network/model.py
+++ b/nova/network/model.py
@@ -77,6 +77,9 @@ VIF_DETAILS_VHOSTUSER_SOCKET = 'vhostuser_socket'
 # Specifies whether vhost-user socket should be plugged
 # into ovs bridge. Valid values are True and False
 VIF_DETAILS_VHOSTUSER_OVS_PLUG = 'vhostuser_ovs_plug'
+# Specifies whether vhost-user mode should be used by vrouter.
+# Valid values are True and False
+VIF_DETAILS_VHOSTUSER_VROUTER_PLUG = 'vhostuser_vrouter_plug'
 
 # Constants for dictionary keys in the 'vif_details' field that are
 # valid for VIF_TYPE_TAP.

--- a/nova/tests/unit/virt/libvirt/test_vif.py
+++ b/nova/tests/unit/virt/libvirt/test_vif.py
@@ -314,6 +314,16 @@ class LibvirtVifTestCase(test.NoDBTestCase):
               ovs_interfaceid='aaa-bbb-ccc'
               )
 
+    vif_vhostuser_vrouter = network_model.VIF(id='vif-xxx-yyy-zzz',
+              address='ca:fe:de:ad:be:ef',
+              network=network_bridge,
+              type=network_model.VIF_TYPE_VHOSTUSER,
+              details = {network_model.VIF_DETAILS_VHOSTUSER_MODE: 'client',
+                       network_model.VIF_DETAILS_VHOSTUSER_SOCKET:
+                                                        '/tmp/usv-xxx-yyy-zzz',
+                       network_model.VIF_DETAILS_VHOSTUSER_VROUTER_PLUG: True},
+              )
+
     vif_vhostuser_no_path = network_model.VIF(id='vif-xxx-yyy-zzz',
           address='ca:fe:de:ad:be:ef',
           network=network_bridge,
@@ -342,7 +352,8 @@ class LibvirtVifTestCase(test.NoDBTestCase):
           network=network_8021,
           type=network_model.VIF_TYPE_MACVTAP)
 
-    instance = objects.Instance(id=1, uuid='instance-uuid')
+    instance = objects.Instance(id=1, uuid='instance-uuid',
+                                project_id=1, display_name='Instance 1')
 
     bandwidth = {
         'quota:vif_inbound_peak': '200',
@@ -1314,3 +1325,84 @@ class LibvirtVifTestCase(test.NoDBTestCase):
             d = vif.LibvirtGenericVIFDriver()
             d.unplug_vhostuser(None, self.vif_vhostuser_ovs)
             delete_port.assert_has_calls(calls['delete_ovs_vif_port'])
+
+    def test_vhostuser_driver_vrouter(self):
+        d = vif.LibvirtGenericVIFDriver()
+        xml = self._get_instance_xml(d,
+                                     self.vif_vhostuser_vrouter)
+        node = self._get_node(xml)
+        self.assertEqual(node.get("type"),
+                         network_model.VIF_TYPE_VHOSTUSER)
+
+        self._assertTypeEquals(node, network_model.VIF_TYPE_VHOSTUSER,
+                               "source", "mode", "client")
+        self._assertTypeEquals(node, network_model.VIF_TYPE_VHOSTUSER,
+                               "source", "path", "/tmp/usv-xxx-yyy-zzz")
+        self._assertTypeEquals(node, network_model.VIF_TYPE_VHOSTUSER,
+                               "source", "type", "unix")
+        self._assertMacEquals(node, self.vif_vhostuser_vrouter)
+        self._assertModel(xml, network_model.VIF_MODEL_VIRTIO)
+
+    def test_vhostuser_vrouter_plug(self):
+        calls = {
+            '_vrouter_port_add': [mock.call(self.instance,
+                                  self.vif_vhostuser_vrouter)]
+        }
+        with mock.patch.object(vif.LibvirtGenericVIFDriver,
+                               '_vrouter_port_add') as port_add:
+            d = vif.LibvirtGenericVIFDriver()
+            d.plug_vhostuser(self.instance, self.vif_vhostuser_vrouter)
+
+            port_add.assert_has_calls(calls['_vrouter_port_add'])
+
+    def test_vhostuser_vrouter_unplug(self):
+        calls = {
+            '_vrouter_port_delete': [mock.call(self.instance,
+                                     self.vif_vhostuser_vrouter)]
+        }
+        with mock.patch.object(vif.LibvirtGenericVIFDriver,
+                               '_vrouter_port_delete') as delete_port:
+            d = vif.LibvirtGenericVIFDriver()
+            d.unplug_vhostuser(self.instance, self.vif_vhostuser_vrouter)
+
+            delete_port.assert_has_calls(calls['_vrouter_port_delete'])
+
+    def test_vrouter_port_add(self):
+        ip_addr = '0.0.0.0'
+        ip6_addr = None
+        ptype = 'NovaVMPort'
+        cmd_args = ("--oper=add --uuid=%s --instance_uuid=%s --vn_uuid=%s "
+                    "--vm_project_uuid=%s --ip_address=%s --ipv6_address=%s"
+                    " --vm_name=%s --mac=%s --tap_name=%s --port_type=%s "
+                    "--tx_vlan_id=%d --rx_vlan_id=%d" %
+                    (self.vif_vhostuser_vrouter['id'],
+                    self.instance.uuid,
+                    self.vif_vhostuser_vrouter['network']['id'],
+                    self.instance.project_id, ip_addr, ip6_addr,
+                    self.instance.display_name,
+                    self.vif_vhostuser_vrouter['address'],
+                    self.vif_vhostuser_vrouter['devname'], ptype, -1, -1))
+        calls = {
+            'execute': [mock.call('vrouter-port-control', cmd_args,
+                                  run_as_root=True)]
+        }
+
+        with mock.patch.object(utils, 'execute') as execute_cmd:
+            d = vif.LibvirtGenericVIFDriver()
+            d._vrouter_port_add(self.instance, self.vif_vhostuser_vrouter)
+
+            execute_cmd.assert_has_calls(calls['execute'])
+
+    def test_vrouter_port_delete(self):
+        cmd_args = ("--oper=delete --uuid=%s" %
+                    (self.vif_vhostuser_vrouter['id']))
+        calls = {
+            'execute': [mock.call('vrouter-port-control', cmd_args,
+                        run_as_root=True)]
+        }
+
+        with mock.patch.object(utils, 'execute') as execute_cmd:
+            d = vif.LibvirtGenericVIFDriver()
+            d._vrouter_port_delete(self.instance, self.vif_vhostuser_vrouter)
+
+            execute_cmd.assert_has_calls(calls['execute'])

--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -655,25 +655,8 @@ class LibvirtGenericVIFDriver(object):
         linux_net.create_tap_dev(dev, mac)
         linux_net._set_device_mtu(dev)
 
-    def plug_vhostuser(self, instance, vif):
-        ovs_plug = vif['details'].get(
-                                network_model.VIF_DETAILS_VHOSTUSER_OVS_PLUG,
-                                False)
-        if ovs_plug:
-            iface_id = self.get_ovs_interfaceid(vif)
-            port_name = os.path.basename(
-                    vif['details'][network_model.VIF_DETAILS_VHOSTUSER_SOCKET])
-            linux_net.create_ovs_vif_port(self.get_bridge_name(vif),
-                                          port_name, iface_id, vif['address'],
-                                          instance.uuid)
-            linux_net.ovs_set_vhostuser_port_type(port_name)
-
-    def plug_vrouter(self, instance, vif):
-        """Plug into Contrail's network port
-
-        Bind the vif to a Contrail virtual port.
-        """
-        dev = self.get_vif_devname(vif)
+    @staticmethod
+    def _vrouter_port_add(instance, vif):
         ip_addr = '0.0.0.0'
         ip6_addr = None
         subnets = vif['network']['subnets']
@@ -694,17 +677,60 @@ class LibvirtGenericVIFDriver(object):
         if (cfg.CONF.libvirt.virt_type == 'lxc'):
             ptype = 'NameSpacePort'
 
+        vif_type = 'Vrouter'
+        vhostuser_socket = ''
+        if vif['type'] == network_model.VIF_TYPE_VHOSTUSER:
+            vif_type = 'VhostUser'
+            vhostuser_socket = '--vhostuser_socket=%s' % \
+                vif['details'][network_model.VIF_DETAILS_VHOSTUSER_SOCKET]
+
         cmd_args = ("--oper=add --uuid=%s --instance_uuid=%s --vn_uuid=%s "
                     "--vm_project_uuid=%s --ip_address=%s --ipv6_address=%s"
                     " --vm_name=%s --mac=%s --tap_name=%s --port_type=%s "
-                    "--tx_vlan_id=%d --rx_vlan_id=%d" % (vif['id'],
-                    instance.uuid, vif['network']['id'],
+                    "--vif_type=%s %s --tx_vlan_id=%d --rx_vlan_id=%d" %
+                    (vif['id'], instance.uuid, vif['network']['id'],
                     instance.project_id, ip_addr, ip6_addr,
                     instance.display_name, vif['address'],
-                    vif['devname'], ptype, -1, -1))
+                    vif['devname'], ptype, vif_type, vhostuser_socket, -1, -1))
+
+        try:
+            utils.execute('vrouter-port-control', cmd_args, run_as_root=True)
+        except processutils.ProcessExecutionError as e:
+            raise exception.VirtualInterfacePlugException(_("Failed to create "
+                "the vRouter port with the command: vrouter-port-control %s" %
+                cmd_args))
+
+    def plug_vhostuser(self, instance, vif):
+        ovs_plug = vif['details'].get(
+                                network_model.VIF_DETAILS_VHOSTUSER_OVS_PLUG,
+                                False)
+        vrouter_plug = vif['details'].get(
+                           network_model.VIF_DETAILS_VHOSTUSER_VROUTER_PLUG,
+                           False)
+        try:
+            if ovs_plug:
+                iface_id = self.get_ovs_interfaceid(vif)
+                port_name = os.path.basename(
+                        vif['details'][network_model.VIF_DETAILS_VHOSTUSER_SOCKET])
+                linux_net.create_ovs_vif_port(self.get_bridge_name(vif),
+                                              port_name, iface_id, vif['address'],
+                                              instance.uuid)
+                linux_net.ovs_set_vhostuser_port_type(port_name)
+
+            elif vrouter_plug:
+                self._vrouter_port_add(instance, vif)
+        except processutils.ProcessExecutionError:
+            LOG.exception(_LE("Failed while plugging vif"), instance=instance)
+
+    def plug_vrouter(self, instance, vif):
+        """Plug into Contrail's network port
+
+        Bind the vif to a Contrail virtual port.
+        """
+        dev = self.get_vif_devname(vif)
         try:
             linux_net.create_tap_dev(dev)
-            utils.execute('vrouter-port-control', cmd_args, run_as_root=True)
+            self._vrouter_port_add(instance, vif)
         except processutils.ProcessExecutionError:
             LOG.exception(_LE("Failed while plugging vif"), instance=instance)
 
@@ -886,15 +912,29 @@ class LibvirtGenericVIFDriver(object):
             LOG.exception(_LE("Failed while unplugging vif"),
                           instance=instance)
 
+    @staticmethod
+    def _vrouter_port_delete(instance, vif):
+        cmd_args = ("--oper=delete --uuid=%s" % (vif['id']))
+        utils.execute('vrouter-port-control', cmd_args, run_as_root=True)
+
     def unplug_vhostuser(self, instance, vif):
         ovs_plug = vif['details'].get(
                         network_model.VIF_DETAILS_VHOSTUSER_OVS_PLUG,
                         False)
-        if ovs_plug:
-            port_name = os.path.basename(
-                    vif['details'][network_model.VIF_DETAILS_VHOSTUSER_SOCKET])
-            linux_net.delete_ovs_vif_port(self.get_bridge_name(vif),
-                                          port_name)
+        vrouter_plug = vif['details'].get(
+                           network_model.VIF_DETAILS_VHOSTUSER_VROUTER_PLUG,
+                           False)
+        try:
+            if ovs_plug:
+                port_name = os.path.basename(
+                        vif['details'][network_model.VIF_DETAILS_VHOSTUSER_SOCKET])
+                linux_net.delete_ovs_vif_port(self.get_bridge_name(vif),
+                                              port_name)
+            elif vrouter_plug:
+                self._vrouter_port_delete(instance, vif)
+        except processutils.ProcessExecutionError:
+            LOG.exception(
+                _LE("Failed while unplugging vif"), instance=instance)
 
     def unplug_vrouter(self, instance, vif):
         """Unplug Contrail's network port
@@ -902,9 +942,8 @@ class LibvirtGenericVIFDriver(object):
         Unbind the vif from a Contrail virtual port.
         """
         dev = self.get_vif_devname(vif)
-        cmd_args = ("--oper=delete --uuid=%s" % (vif['id']))
         try:
-            utils.execute('vrouter-port-control', cmd_args, run_as_root=True)
+            self._vrouter_port_delete(instance, vif)
             linux_net.delete_net_dev(dev)
         except processutils.ProcessExecutionError:
             LOG.exception(


### PR DESCRIPTION
OpenContrail vRouter can be used as a userspace DPDK based virtual switch
application that uses QEMU's vhost-user interface types. This requires adding
support for vRouter in {plug, unplug}_vhostuser() methods similarly as it is
done for OVS.

This is import from the Kilo branch of these commits:
- 254db56b11e3f3446a00a095754eb2bc3837e362 "libvirt, vhostuser: Add support for
  OpenContrail vRouter"
- d12f37a096d68354d7b3225b7321b573c4cefa26 "Handle exception in plug and unplug
  functions for vrouter and vhostuser"
- c49d206038a9f8a8ab1fd1d652d444fa0e9faae9 "Handle new command line options of
  vrouter-port-control"

Change-Id: Iefa4738a92e10f0ee5703a6afbb81542373976c1
Closes-Bug: #1561163